### PR TITLE
Added：パイプから標準入力を受け取れるように修正

### DIFF
--- a/cmd/nabeatsu/main.go
+++ b/cmd/nabeatsu/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"syscall"
@@ -26,10 +25,11 @@ Usage:
 	if hasPipeData() {
 		stdin, err := io.ReadAll(os.Stdin)
 		if err != nil {
-			log.Fatal("パイプから入力を受け取れませんでした")
+			fmt.Fprintf(os.Stderr, "パイプから入力を受け取れませんでした")
+			os.Exit(1)
 		}
 
-		list := chopAll(strings.Split(string(stdin), "\n"))
+		list := strings.Split(string(stdin), "\n")
 		if list[len(list)-1] == "" {
 			list = list[:len(list)-1]
 		}
@@ -45,21 +45,4 @@ Usage:
 // hasPipeData は、パイプから標準入力を受け取っているかどうかを返す。
 func hasPipeData() bool {
 	return !term.IsTerminal(syscall.Stdin)
-}
-
-// chop は、文字列の末尾から改行コードを削除する。
-func chop(line string) string {
-	if strings.HasSuffix(line, "\n") {
-		return strings.TrimLeft(line, "\n")
-	}
-	return line
-}
-
-// chop は、文字列リストから文字列を取り出し、それら文字列末尾の改行コードを削除する。
-func chopAll(lines []string) []string {
-	var newLines []string
-	for _, v := range lines {
-		newLines = append(newLines, chop(v))
-	}
-	return newLines
 }

--- a/cmd/nabeatsu/main.go
+++ b/cmd/nabeatsu/main.go
@@ -2,13 +2,18 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
+	"strings"
+	"syscall"
 
 	"github.com/furusax0621/go-nabeatsu"
+	"golang.org/x/term"
 )
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) < 2 && !hasPipeData() {
 		fmt.Println(`
 世界のナベアツは3の倍数と3のつく数字のときだけ阿呆になります。
 
@@ -17,5 +22,44 @@ Usage:
 		)
 		os.Exit(0)
 	}
+
+	if hasPipeData() {
+		stdin, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Fatal("パイプから入力を受け取れませんでした")
+		}
+
+		list := chopAll(strings.Split(string(stdin), "\n"))
+		if list[len(list)-1] == "" {
+			list = list[:len(list)-1]
+		}
+
+		for _, s := range list {
+			fmt.Println(nabeatsu.GetFoolExpression(s))
+		}
+		os.Exit(0)
+	}
 	fmt.Println(nabeatsu.GetFoolExpression(os.Args[1]))
+}
+
+// hasPipeData は、パイプから標準入力を受け取っているかどうかを返す。
+func hasPipeData() bool {
+	return !term.IsTerminal(syscall.Stdin)
+}
+
+// chop は、文字列の末尾から改行コードを削除する。
+func chop(line string) string {
+	if strings.HasSuffix(line, "\n") {
+		return strings.TrimLeft(line, "\n")
+	}
+	return line
+}
+
+// chop は、文字列リストから文字列を取り出し、それら文字列末尾の改行コードを削除する。
+func chopAll(lines []string) []string {
+	var newLines []string
+	for _, v := range lines {
+		newLines = append(newLines, chop(v))
+	}
+	return newLines
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/furusax0621/go-nabeatsu
 
 go 1.17
+
+require golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+
+require golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
指示を受けたので……ちょっと改善を……
![image](https://user-images.githubusercontent.com/22737008/150661526-89bb6b05-e40a-459f-bde4-48f312622d61.png)

## 従来の使い方
```
$ ./main 12
ｼﾞｭｳﾆwww
```

## 本Pull Requestで出来ること
パイプに対応したので、seqコマンドで大量に数値を受け取れます。
余談ですが、"$ seq 1000000000000000000000000000000000 | ./main > test.txt"は過負荷でコマンドが落ちます。
```
$ seq 40 | ./main 
1
2
ｻｧﾝwww
4
5
ﾛｸwww
7
8
ｷｭｳwww
10
11
ｼﾞｭｳﾆwww
ｼﾞｭｳｻｧﾝwww
14
ｼﾞｭｳｺﾞwww
16
17
ｼﾞｭｳﾊﾁwww
19
20
ﾆｼﾞｭｳｲﾁwww
22
ﾆｼﾞｭｳｻｧﾝwww
ﾆｼﾞｭｳﾖﾝwww
25
26
ﾆｼﾞｭｳﾅﾅwww
28
29
ｻｧﾝｼﾞｭｳwww
ｻｧﾝｼﾞｭｳｲﾁwww
ｻｧﾝｼﾞｭｳﾆwww
ｻｧﾝｼﾞｭｳｻｧﾝwww
ｻｧﾝｼﾞｭｳﾖﾝwww
ｻｧﾝｼﾞｭｳｺﾞwww
ｻｧﾝｼﾞｭｳﾛｸwww
ｻｧﾝｼﾞｭｳﾅﾅwww
ｻｧﾝｼﾞｭｳﾊﾁwww
ｻｧﾝｼﾞｭｳｷｭｳwww
40
```